### PR TITLE
fix: Fix `go` module name and swift bindings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,10 +3,13 @@ import PackageDescription
 
 let package = Package(
     name: "TreeSitterGaptst",
+    defaultLocalization: "en",
     products: [
         .library(name: "TreeSitterGaptst", targets: ["TreeSitterGaptst"]),
     ],
-    dependencies: [],
+    dependencies: [
+        .package(url: "https://github.com/ChimeHQ/SwiftTreeSitter", from: "0.8.0"),
+    ],
     targets: [
         .target(name: "TreeSitterGaptst",
                 dependencies: [],

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # tree-sitter-gaptst
 
+[![CI][ci]](https://github.com/gap-system/tree-sitter-gaptst/actions/workflows/ci.yml)
+
 [tree-sitter](https://github.com/tree-sitter/tree-sitter) grammar for
 [GAP system test files](https://docs.gap-system.org/doc/ref/chap7_mj.html#X801051CC86594630).
 

--- a/bindings/go/binding_test.go
+++ b/bindings/go/binding_test.go
@@ -9,6 +9,7 @@ import (
 
 func TestCanLoadGrammar(t *testing.T) {
 	language := tree_sitter.NewLanguage(tree_sitter_gaptst.Language())
+
 	if language == nil {
 		t.Errorf("Error loading gaptst grammar")
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/tree-sitter/tree-sitter-gaptst
+module github.com/gap-system/tree-sitter-gaptst
 
 go 1.23
 


### PR DESCRIPTION
Fix `go` module name for CI to pass